### PR TITLE
Add command to create new localization file from master file

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,11 +1,13 @@
 import * as addString from './addString.js';
 import * as change from './change.js';
 import * as delString from './delString.js';
+import * as newLocale from './newLocale.js';
 import * as sort from './sort.js';
 
 export const commands = [
 	addString,
 	delString,
 	sort,
-	change
+	change,
+	newLocale
 ];

--- a/src/commands/newLocale.ts
+++ b/src/commands/newLocale.ts
@@ -1,0 +1,41 @@
+import type { ArgumentsCamelCase, Argv } from 'yargs';
+
+import { newLocale } from '../modifiers/newLocale';
+
+export const command = 'new';
+export const description = 'Create new localization file from master file';
+
+export function builder(yargs: Argv) {
+	return yargs
+		.option('name', {
+			alias: 'n',
+			desc: 'Name of new localization file',
+			demandOption: true,
+			type: 'string'
+		})
+		.option('master', {
+			alias: 'm',
+			desc: 'Master localization file',
+			demandOption: true,
+			type: 'string'
+		})
+		.option('directory', {
+			alias: 'dir',
+			desc: 'Directory of localization files',
+			type: 'string',
+			default: 'mock'
+		})
+		.usage(`\nExample:\n $0 ${command} -n strings-kz.xml -m strings.xml`);
+}
+
+export async function handler({
+	name,
+	master,
+	directory
+}: ArgumentsCamelCase<{
+	name: string;
+	master: string;
+	directory: string;
+}>) {
+	newLocale({ name, master, directory });
+}

--- a/src/modifiers/newLocale.ts
+++ b/src/modifiers/newLocale.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+
+export function newLocale(options: {
+	name: string;
+	master: string;
+	directory: string;
+}) {
+	const { name, master, directory } = options;
+
+	fs.copyFile(`${directory}/${master}`, `${directory}/${name}`, (err) => {
+		if (err) {
+			console.error(err);
+
+			return;
+		}
+		console.log(`${master} was copied to ${directory}/${name}`);
+	});
+}


### PR DESCRIPTION
This pull request adds a new command to create a new localization file from a master file. The new command is called "new" and takes three options: "name" (the name of the new file), "master" (the name of the master file), and "directory" (the directory where the files are located)