### PR TITLE
Make index file executable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 


### PR DESCRIPTION
This pull request adds the shebang line `#!/usr/bin/env node` to the index file, making it executable. This change allows the file to be run as a command-line script.