### PR TITLE
chore: changed default options for xml parser and builder. 

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @xml-locales/cli
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - xml-locales@0.0.4
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xml-locales/cli",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"type": "module",
 	"bin": {
 		"xml-locales": "./dist/bin.js"
@@ -28,7 +28,7 @@
 	"dependencies": {
 		"@inquirer/prompts": "3.3.0",
 		"@types/yargs": "17.0.32",
-		"xml-locales": "workspace:0.0.3",
+		"xml-locales": "workspace:0.0.4",
 		"yargs": "17.7.2"
 	}
 }

--- a/packages/xml-locales/CHANGELOG.md
+++ b/packages/xml-locales/CHANGELOG.md
@@ -1,5 +1,11 @@
 # xml-locales
 
+## 0.0.4
+
+### Patch Changes
+
+- fix default options for xml parser and builder
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/xml-locales/package.json
+++ b/packages/xml-locales/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "xml-locales",
 	"description": "Tool for locales in xml files",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"type": "module",
 	"keywords": [
 		"xml-locales",

--- a/packages/xml-locales/src/utils/xml.ts
+++ b/packages/xml-locales/src/utils/xml.ts
@@ -15,7 +15,7 @@ export interface XmlConstructor {
 }
 
 const defaultParserOptions: X2jOptionsOptional = {
-	trimValues: true,
+	trimValues: false,
 	ignoreDeclaration: true,
 	attributeNamePrefix: 'key_',
 	alwaysCreateTextNode: true,
@@ -24,7 +24,8 @@ const defaultParserOptions: X2jOptionsOptional = {
 
 const defaultBuilderOptions: XmlBuilderOptionsOptional = {
 	ignoreAttributes: false,
-	attributeNamePrefix: 'key_'
+	attributeNamePrefix: 'key_',
+	processEntities: false
 };
 
 const defaultFormatterOptions: XMLFormatterOptions = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: 17.0.32
         version: 17.0.32
       xml-locales:
-        specifier: workspace:0.0.3
+        specifier: workspace:0.0.4
         version: link:../xml-locales
       yargs:
         specifier: 17.7.2


### PR DESCRIPTION
Do not trimming values, and don't convert chars to HTML Entities